### PR TITLE
Pound allow external URL redirects

### DIFF
--- a/pound.cfg
+++ b/pound.cfg
@@ -42,6 +42,10 @@ ListenHTTPS
 	## allow PUT and DELETE also (by default only GET, POST and HEAD)?:
 	xHTTP	1
 
+    # Allow for redirection to external URLs
+    RewriteLocation 0
+    RewriteDestination 1
+
 	HeadRemove	"X-Forwarded-Proto"
 	AddHeader	"X-Forwarded-Proto: https"
 


### PR DESCRIPTION
Closes #3555

Adding `RewriteLocation 0` and `RewriteDestination 1` directives to the pound.cfg.

Setting `RewriteLocation` to 0 essentially disallows the rewrite of the host when we are trying to hit an external URL. Meaning if we are on `https://dev.wellthy.com` and  we try to download a document from a project it will try to redirect us to `https://wellthy-test.s3.amazon.com/path/to/document`, however since `RewriteLocation` default value is 1 it will rewrite the host of that URL in question back to `dev.wellthy.com`. Setting `RewriteLocation` to 0 disables this behavior and allows us to properly navigate to the external S3 URL.

Please reference the below details of both directives from the man-page of pound(8):

**RewriteLocation 0|1|2**
If 1 force Pound to change the Location: and Content-location: headers in responses. If they point to the back-end itself or to the listener (but with the wrong protocol) the response will be changed to show the virtual host in the request. Default: 1 (active). If the value is set to 2 only the back-end address is compared; this is useful for redirecting a request to an HTTPS listener on the same server as the HTTP listener. 

**RewriteDestination 0|1**
If 1 force Pound to change the Destination: header in requests. The header is changed to point to the back-end itself with the correct protocol. Default: 0. 

- https://linux.die.net/man/8/pound